### PR TITLE
Don't specify 'stable' branch

### DIFF
--- a/info.bibletime.BibleTime.json
+++ b/info.bibletime.BibleTime.json
@@ -1,6 +1,5 @@
 {
   "id": "info.bibletime.BibleTime",
-  "branch": "stable",
   "sdk": "org.kde.Sdk",
   "runtime": "org.kde.Platform",
   "runtime-version": "5.11",


### PR DESCRIPTION
This is injected by the buildbots and not having it in the manifest makes it easier to test local builds.