### PR TITLE
Release BibleTime 3.1.1 with native wayland support.

### DIFF
--- a/info.bibletime.BibleTime.json
+++ b/info.bibletime.BibleTime.json
@@ -5,7 +5,8 @@
   "runtime-version": "6.8",
   "command": "bibletime",
   "finish-args": [
-    "--socket=x11",
+    "--socket=wayland",
+    "--socket=fallback-x11",
     "--share=ipc",
     "--share=network",
     "--persist=.bibletime",


### PR DESCRIPTION
Release BibleTime 3.1.1 with native wayland support.